### PR TITLE
foreground and background colors supports opacity modifier

### DIFF
--- a/src/app/(e-commerce)/collections/[name]/page.tsx
+++ b/src/app/(e-commerce)/collections/[name]/page.tsx
@@ -50,7 +50,7 @@ export default async function Page({ params }: Props) {
           />
         </div>
       </section>
-      <div className="flex mb-4 mt-10 text-xs text-gray-500">
+      <div className="flex mb-4 mt-10 text-xs text-foreground/50">
         <div className="grow"></div>
         <div>{length} products</div>
       </div>

--- a/src/app/(e-commerce)/page.tsx
+++ b/src/app/(e-commerce)/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
               <Tabs.Trigger
                 key={collection}
                 value={collection}
-                className="text-gray-700 data-[state=active]:text-foreground after:content-[''] after:block after:mt-2
+                className="text-foreground/70 data-[state=active]:text-foreground after:content-[''] after:block after:mt-2
                             after:border-b-2 after:border-foreground after:transition-transform 
                             after:scale-0 data-[state=active]:after:scale-100 hover:after:scale-100"
               >

--- a/src/app/(e-commerce)/products/[id]/form.tsx
+++ b/src/app/(e-commerce)/products/[id]/form.tsx
@@ -13,7 +13,7 @@ export default function Form({
     <form>
       <div className="flex flex-col gap-2 mb-8 text-xs">
         <p className="font-bold">
-          Color: <span className="text-gray-500">{selectedColor}</span>
+          Color: <span className="text-foreground/50">{selectedColor}</span>
         </p>
         <ColorPicker
           value={selectedColor}

--- a/src/app/(e-commerce)/products/[id]/page.tsx
+++ b/src/app/(e-commerce)/products/[id]/page.tsx
@@ -82,7 +82,7 @@ export default async function Page({ params }: Props) {
           </div>
         </div>
       </section>
-      <section className="bg-gray-50 py-10 mt-10">
+      <section className="bg-foreground/5 py-10 mt-10">
         <div className="container mx-auto flex-col-center">
           <h2 className="text-lg font-bold">Crafted for every occasion</h2>
           <hr className="divider mt-3.5 mb-10" />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,8 +4,8 @@
 
 @layer base {
   :root {
-    --background: #ffffff;
-    --foreground: #171717;
+    --background: 255 255 255;
+    --foreground: 23 23 23;
   }
 
   /* @media (prefers-color-scheme: dark) {

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -9,14 +9,14 @@ export default function Breadcrumb({ crumbs }: IProps) {
     <nav aria-label="breadcrumb">
       <ol className="flex-row-center text-xs justify-center">
         {crumbs.map((crumb, index) => (
-          <li key={index} className="text-gray-600 last:text-foreground">
+          <li key={index} className="text-foreground/60 last:text-foreground">
             {crumb.path ? (
               <NextLink href={crumb.path}>{crumb.name}</NextLink>
             ) : (
               crumb.name
             )}
             {index !== crumbs.length - 1 && (
-              <span className="mx-2 text-gray-400">&gt;</span>
+              <span className="mx-2 text-foreground/40">&gt;</span>
             )}
           </li>
         ))}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,8 +14,8 @@ const config: Config = {
         mono: ["var(--font-geist-mono)"],
       },
       colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+        background: "rgb(var(--background))",
+        foreground: "rgb(var(--foreground))",
         primary: colors.yellow[700],
       },
     },


### PR DESCRIPTION
This pull request includes several changes to improve the consistency and appearance of the e-commerce application by updating color variables and their usage across various components. The primary focus is on replacing hardcoded color values with CSS variables and updating the Tailwind configuration to use the new color format.

Color consistency improvements:

* [`src/app/globals.css`](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L7-R8): Updated the `--background` and `--foreground` CSS variables to use RGB values instead of hex values.
* [`tailwind.config.ts`](diffhunk://#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40L17-R18): Modified the `background` and `foreground` colors to use the new RGB format for CSS variables.

Component updates:

* `src/app/(e-commerce)/collections/[name]/page.tsx`: Changed the text color class from `text-gray-500` to `text-foreground/50` for improved consistency. ([src/app/(e-commerce)/collections/[name]/page.tsxL53-R53](diffhunk://#diff-7ef3299a02c42e576a819a891a1f105174634f20ad9cdf53b1755c20fbd39f41L53-R53))
* [`src/app/(e-commerce)/page.tsx`](diffhunk://#diff-f47bfdafa1899f9769eac5fa015a6596f05516977d51ce260b5d315ebe2af6e4L42-R42): Updated the `Tabs.Trigger` component to use `text-foreground/70` instead of `text-gray-700` for better alignment with the new color scheme.
* `src/app/(e-commerce)/products/[id]/form.tsx`: Replaced `text-gray-500` with `text-foreground/50` for the selected color text. ([src/app/(e-commerce)/products/[id]/form.tsxL16-R16](diffhunk://#diff-3a9343c308e81fccb862ca44bf8fda5bd102d3611f4e1c7cc273064a6f31b03eL16-R16))
* `src/app/(e-commerce)/products/[id]/page.tsx`: Updated the background color class from `bg-gray-50` to `bg-foreground/5` for the section. ([src/app/(e-commerce)/products/[id]/page.tsxL85-R85](diffhunk://#diff-399c8fbf0eddb4881e27d2577e2ef70c953215f4f74e1e2b45eb2f05e8d88ffaL85-R85))
* [`src/components/Breadcrumb.tsx`](diffhunk://#diff-34d4b64b26bd09784c39412063d5cef930424d4f36c9ea16c1eb003bb0dcbe79L12-R19): Changed the breadcrumb text color from `text-gray-600` to `text-foreground/60` and the separator color from `text-gray-400` to `text-foreground/40`.